### PR TITLE
Feat: Implement toggle `bubble` mode

### DIFF
--- a/.chatty.default.toml
+++ b/.chatty.default.toml
@@ -12,6 +12,8 @@ bubble_width_percent = 60
 # If set, the initialize screen will auto close after the inititalization
 # is done.
 auto_start = false
+# Enable bubble chat or not. Default is true
+bubble = true
 
 [log]
 # Default log level is "info"

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -271,7 +271,7 @@ impl<'a> App<'a> {
                 self.input.paste();
             }
 
-            Event::KeyboardAltEnter => {
+            Event::KeyboardNewLine => {
                 if !self.on_waiting_backend(false) {
                     self.input.insert_newline();
                 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -12,10 +12,14 @@ pub use initializer::Initializer;
 
 use crossterm::{
     cursor,
-    event::{DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture},
+    event::{
+        DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
+        EnableFocusChange, EnableMouseCapture, KeyboardEnhancementFlags,
+        PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+    },
     terminal::{
-        EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
-        is_raw_mode_enabled,
+        Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode,
+        enable_raw_mode, is_raw_mode_enabled,
     },
 };
 use eyre::{Context, Result};
@@ -26,9 +30,11 @@ pub fn destruct_terminal() {
             let _ = disable_raw_mode();
             let _ = crossterm::execute!(
                 io::stdout(),
-                LeaveAlternateScreen,
                 DisableMouseCapture,
-                DisableBracketedPaste
+                PopKeyboardEnhancementFlags,
+                DisableBracketedPaste,
+                DisableFocusChange,
+                LeaveAlternateScreen,
             );
             let _ = crossterm::execute!(io::stdout(), cursor::Show);
         }
@@ -41,8 +47,14 @@ pub fn init_terminal() -> Result<()> {
     crossterm::execute!(
         stdout,
         EnterAlternateScreen,
+        EnableFocusChange,
+        Clear(ClearType::All),
         EnableMouseCapture,
-        EnableBracketedPaste
+        EnableBracketedPaste,
+        PushKeyboardEnhancementFlags(
+            KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
+        )
     )?;
     Ok(())
 }

--- a/src/app/services/events.rs
+++ b/src/app/services/events.rs
@@ -22,8 +22,8 @@ impl EventService {
             },
             CrosstermEvent::Key(key_event) => {
                 let input: Input = key_event.into();
-                if input.alt && input.key == Key::Enter {
-                    return Some(Event::KeyboardAltEnter);
+                if input.key == Key::Enter && (input.shift || input.alt || input.ctrl) {
+                    return Some(Event::KeyboardNewLine);
                 }
 
                 // Map ctrl events

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -15,6 +15,7 @@ pub mod utils;
 
 pub use bubble::Bubble;
 pub use bubble_list::BubbleList;
+
 pub use edit::EditScreen;
 pub use help::HelpScreen;
 pub use history::HistoryScreen;

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -51,6 +51,9 @@ pub struct GeneralConfig {
 
     #[serde(default)]
     pub auto_start: Option<bool>,
+
+    #[serde(default = "default_option_true")]
+    pub bubble: Option<bool>,
 }
 
 #[derive(Default, Deserialize, Serialize, Debug, Clone)]
@@ -270,6 +273,7 @@ impl Default for GeneralConfig {
             show_usage: None,
             bubble_width_percent: 80,
             auto_start: None,
+            bubble: default_option_true(),
         }
     }
 }

--- a/src/models/event.rs
+++ b/src/models/event.rs
@@ -20,7 +20,7 @@ pub enum Event {
     KeyboardCharInput(Input),
     KeyboardEsc,
     KeyboardEnter,
-    KeyboardAltEnter,
+    KeyboardNewLine,
     KeyboardCtrlC,
     KeyboardCtrlR,
     KeyboardCtrlN,
@@ -72,7 +72,7 @@ impl Event {
             Event::KeyboardCharInput(_)
                 | Event::KeyboardEsc
                 | Event::KeyboardEnter
-                | Event::KeyboardAltEnter
+                | Event::KeyboardNewLine
                 | Event::KeyboardCtrlC
                 | Event::KeyboardCtrlR
                 | Event::KeyboardCtrlN


### PR DESCRIPTION
### Changes
* Allow to enable/disable `bubble` chat in settings.
* Allow insert new line with `Ctrl+Enter` and `Shift+Enter`. Note: This feature currently doesn't work with `tmux`.